### PR TITLE
Run Cargo fmt and setup CI to verify it

### DIFF
--- a/.github/workflows/rust_tests.yml
+++ b/.github/workflows/rust_tests.yml
@@ -7,6 +7,17 @@ on:
   pull_request:
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Clippy
+        run: cargo fmt --all --check
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust_tests.yml
+++ b/.github/workflows/rust_tests.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Clippy
+      - name: Format
         run: cargo fmt --all --check
 
   clippy:

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,7 +60,6 @@ async fn display_users(pool: &PgPool) -> color_eyre::Result<()> {
     Ok(())
 }
 
-
 async fn sign_up(pool: &PgPool, username_opt: Option<String>) -> color_eyre::Result<()> {
     if Path::new("auth.txt").exists() {
         check_status(pool).await?;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,16 +1,14 @@
+use color_eyre::Result;
 pub use sqlx;
 use sqlx::postgres::PgPoolOptions;
 pub use sqlx::PgPool;
-use color_eyre::Result;
 use uuid::Uuid;
-
 
 #[derive(sqlx::FromRow)]
 pub struct User {
     pub user_id: Uuid,
     pub user_name: String,
 }
-
 
 /// Creates a new user with the given username.
 ///
@@ -40,26 +38,27 @@ pub async fn create_user(pool: &PgPool, user_name: &str) -> color_eyre::Result<U
 pub async fn get_users(pool: &PgPool) -> Result<Vec<User>> {
     let users = sqlx::query_as!(
         User,
-         " 
+        " 
          SELECT user_id, user_name 
          FROM Users
          ",
-    ).fetch_all(pool).await?;
+    )
+    .fetch_all(pool)
+    .await?;
 
     Ok(users)
 }
 
-pub async fn get_username_by_id(pool: &PgPool, user_id: Uuid) -> color_eyre::Result<Option<String>> {
-    let record = sqlx::query!(
-        "SELECT user_name FROM Users WHERE user_id = $1",
-        user_id
-    )
-    .fetch_optional(pool)
-    .await?;
+pub async fn get_username_by_id(
+    pool: &PgPool,
+    user_id: Uuid,
+) -> color_eyre::Result<Option<String>> {
+    let record = sqlx::query!("SELECT user_name FROM Users WHERE user_id = $1", user_id)
+        .fetch_optional(pool)
+        .await?;
 
     Ok(record.map(|r| r.user_name))
 }
-
 
 #[tracing::instrument(err)]
 pub async fn setup_db_pool() -> color_eyre::Result<PgPool> {

--- a/deny.toml
+++ b/deny.toml
@@ -109,7 +109,7 @@ deny = [
   #"Nokia",
 ]
 # Lint level for licenses considered copyleft
-copyleft = "warn"
+copyleft = "deny"
 # Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
 # * both - The license will be approved if it is both OSI-approved *AND* FSF
 # * either - The license will be approved if it is either OSI-approved *OR* FSF
@@ -133,6 +133,7 @@ exceptions = [
   # Each entry is the crate and version constraint, and its specific allow
   # list
   #{ allow = ["Zlib"], name = "adler32", version = "*" },
+  { allow = ["MPL-2.0"], name = "webpki-roots", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,

--- a/deny.toml
+++ b/deny.toml
@@ -184,11 +184,11 @@ wildcards = "allow"
 # * all - Both lowest-version and simplest-path are used
 highlight = "all"
 # The default lint level for `default` features for crates that are members of
-# the workspace that is being checked. This can be overriden by allowing/denying
+# the workspace that is being checked. This can be overridden by allowing/denying
 # `default` on a crate-by-crate basis if desired.
 workspace-default-features = "allow"
 # The default lint level for `default` features for external crates that are not
-# members of the workspace. This can be overriden by allowing/denying `default`
+# members of the workspace. This can be overridden by allowing/denying `default`
 # on a crate-by-crate basis if desired.
 external-default-features = "allow"
 # List of crates that are allowed. Use with care!


### PR DESCRIPTION
`cargo fmt` can be used to format your code and keeps most Rust code looking relatively consistent which is nice!

This formats the existing code and setups up a CI job to enforce the format in PRs

In VS Code you can configure it to run format on save, so that this happens automatically and you don't really need to think about it at all!

https://stackoverflow.com/a/72282191