### PR TITLE
Ticket 283 category create tags

### DIFF
--- a/.sqlx/query-e00f7541d12980aeb81b1262ae1ac99387aa58722994825122a2f85145c5972d.json
+++ b/.sqlx/query-e00f7541d12980aeb81b1262ae1ac99387aa58722994825122a2f85145c5972d.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO Category (markdown_id, category) VALUES ($1, $2) RETURNING *",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "markdown_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "category",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "e00f7541d12980aeb81b1262ae1ac99387aa58722994825122a2f85145c5972d"
+}

--- a/db/migrations/20240613150913_category.down.sql
+++ b/db/migrations/20240613150913_category.down.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+DROP TABLE IF EXISTS category;

--- a/db/migrations/20240613150913_category.up.sql
+++ b/db/migrations/20240613150913_category.up.sql
@@ -1,5 +1,5 @@
 -- Add migration script here
 CREATE TABLE IF NOT EXISTS Category (
-    note_id UUID PRIMARY KEY,
+    markdown_id UUID PRIMARY KEY REFERENCES Markdown(markdown_id),
     category TEXT
 );

--- a/db/migrations/20240613150913_category.up.sql
+++ b/db/migrations/20240613150913_category.up.sql
@@ -1,0 +1,5 @@
+-- Add migration script here
+CREATE TABLE IF NOT EXISTS Category (
+    note_id UUID PRIMARY KEY,
+    category TEXT
+);

--- a/db/src/openai_utils.rs
+++ b/db/src/openai_utils.rs
@@ -34,7 +34,8 @@ pub async fn generate_summary(content: &str) -> Result<String> {
 }
 
 pub async fn generate_categories(content: &str) -> Result<String> {
-    let prompt = format!("Provide a unique category title for the following article. Do not exceed two words: {content}");
+    let prompt = format!("Provide unique categories for the following article. Do not exceed two words per category. Separate categories with commas:
+: {content}");
     let response = generate_openai_response(&prompt, 100).await?;
     let category = response
         .split(',')

--- a/db/src/openai_utils.rs
+++ b/db/src/openai_utils.rs
@@ -6,14 +6,12 @@ async fn generate_openai_response(prompt: &str, max_tokens: u64) -> Result<Strin
     let api_key = env::var("OPEN_AI_API_KEY").expect("OPEN_AI_API_KEY must be set");
     openai::set_key(api_key);
 
-    let messages = vec![
-        ChatCompletionMessage {
-            role: ChatCompletionMessageRole::User,
-            content: Some(prompt.to_string()),
-            name: None,
-            function_call: None,
-        },
-    ];
+    let messages = vec![ChatCompletionMessage {
+        role: ChatCompletionMessageRole::User,
+        content: Some(prompt.to_string()),
+        name: None,
+        function_call: None,
+    }];
     let request = ChatCompletionBuilder::default()
         .model("gpt-4o".to_string())
         .messages(messages)
@@ -38,6 +36,11 @@ pub async fn generate_summary(content: &str) -> Result<String> {
 pub async fn generate_categories(content: &str) -> Result<String> {
     let prompt = format!("Extract key topics or themes from the following article and genrate a two word unique category title. Do not exceed two words: {content}");
     let response = generate_openai_response(&prompt, 100).await?;
-    let category = response.split(',').next().unwrap_or_default().trim().to_string();
+    let category = response
+        .split(',')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
     Ok(category)
 }

--- a/db/src/openai_utils.rs
+++ b/db/src/openai_utils.rs
@@ -2,14 +2,14 @@ use color_eyre::Result;
 use openai::chat::{ChatCompletionBuilder, ChatCompletionMessage, ChatCompletionMessageRole};
 use std::env;
 
-pub async fn generate_summary(content: &str) -> Result<String> {
+async fn generate_openai_response(prompt: &str, max_tokens: u64) -> Result<String> {
     let api_key = env::var("OPEN_AI_API_KEY").expect("OPEN_AI_API_KEY must be set");
     openai::set_key(api_key);
 
     let messages = vec![
         ChatCompletionMessage {
             role: ChatCompletionMessageRole::User,
-            content: Some(format!("Provide a concise summary of the following article that can be read and understood in 2 minutes, focusing on the main points and essential details: {content}")),
+            content: Some(prompt.to_string()),
             name: None,
             function_call: None,
         },
@@ -17,15 +17,27 @@ pub async fn generate_summary(content: &str) -> Result<String> {
     let request = ChatCompletionBuilder::default()
         .model("gpt-4o".to_string())
         .messages(messages)
-        .max_tokens(4096u64)
+        .max_tokens(max_tokens)
         .temperature(0.7)
         .build()?;
 
     let response = openai::chat::ChatCompletion::create(&request).await?;
-    let summary = response.choices[0]
+    let content = response.choices[0]
         .message
         .content
         .clone()
         .unwrap_or_default();
-    Ok(summary)
+    Ok(content)
+}
+
+pub async fn generate_summary(content: &str) -> Result<String> {
+    let prompt = format!("Provide a concise summary of the following article that can be read and understood in 2 minutes, focusing on the main points and essential details: {content}");
+    generate_openai_response(&prompt, 4096).await
+}
+
+pub async fn generate_categories(content: &str) -> Result<String> {
+    let prompt = format!("Extract key topics or themes from the following article and genrate a two word unique category title. Do not exceed two words: {content}");
+    let response = generate_openai_response(&prompt, 100).await?;
+    let category = response.split(',').next().unwrap_or_default().trim().to_string();
+    Ok(category)
 }

--- a/db/src/openai_utils.rs
+++ b/db/src/openai_utils.rs
@@ -34,7 +34,7 @@ pub async fn generate_summary(content: &str) -> Result<String> {
 }
 
 pub async fn generate_categories(content: &str) -> Result<String> {
-    let prompt = format!("Extract key topics or themes from the following article and genrate a two word unique category title. Do not exceed two words: {content}");
+    let prompt = format!("Provide a unique category title for the following article. Do not exceed two words: {content}");
     let response = generate_openai_response(&prompt, 100).await?;
     let category = response
         .split(',')

--- a/db/src/urls.rs
+++ b/db/src/urls.rs
@@ -8,7 +8,7 @@ pub use sqlx::PgPool;
 use url::Url;
 use uuid::Uuid;
 
-use crate::openai_utils::{generate_summary, generate_categories};
+use crate::openai_utils::{generate_categories, generate_summary};
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct Page {
@@ -119,7 +119,7 @@ async fn store_markdown(
 ) -> color_eyre::Result<Markdown> {
     let markdown_content = html2md::parse_html(cleaned_html);
     let summary = generate_summary(&markdown_content).await?;
-    // println!("Summary: {summary}");
+    println!("Summary: {summary}");
 
     let markdown_result = sqlx::query_as!(
         Markdown,
@@ -159,13 +159,13 @@ async fn store_raw_html_in_page_snapshot(
     .await?;
 
     let markdown_result = store_markdown(pool, result.page_snapshot_id, &cleaned_html).await?;
-    // println!("Markdown result: {markdown_result:?}");
+    println!("Markdown result: {markdown_result:?}");
 
     Ok(result)
 }
 
 pub async fn process_page_snapshot(pool: &PgPool, page: Page) -> color_eyre::Result<()> {
     let outcome = store_raw_html_in_page_snapshot(pool, page).await?;
-    // println!("Outcome: {outcome:?}");
+    println!("Outcome: {outcome:?}");
     Ok(())
 }

--- a/db/src/urls.rs
+++ b/db/src/urls.rs
@@ -133,7 +133,7 @@ async fn store_markdown(
 
     let category = generate_categories(&markdown_content).await?;
     let category_result = store_category(pool, markdown_result.markdown_id, &category).await?;
-    println!("Category result: {:?}", category_result);
+    println!("Category result: {category_result:?}");
 
     Ok(markdown_result)
 }

--- a/db/src/urls.rs
+++ b/db/src/urls.rs
@@ -116,8 +116,9 @@ async fn store_markdown(
     cleaned_html: &str,
 ) -> color_eyre::Result<Markdown> {
     let markdown_content = html2md::parse_html(cleaned_html);
+    // println!("Markdown content: {markdown_content}");
     let summary = generate_summary(&markdown_content).await?;
-    // println!("Summary: {summary}");
+    println!("Summary: {summary}");
 
     let markdown_result = sqlx::query_as!(
         Markdown,
@@ -131,7 +132,7 @@ async fn store_markdown(
     let category = generate_categories(&markdown_content).await?;
     // println!("Category: {:?}", category);
     let category_result = store_category(pool, &category).await?;
-    println!("Category result: {:?}", category_result);
+    // println!("Category result: {:?}", category_result);
 
     Ok(markdown_result)
 }

--- a/db/src/urls.rs
+++ b/db/src/urls.rs
@@ -1,4 +1,3 @@
-use openai::chat::{ChatCompletionBuilder, ChatCompletionMessage, ChatCompletionMessageRole};
 use readability;
 use readability::extractor;
 
@@ -6,9 +5,10 @@ use reqwest;
 pub use sqlx;
 use sqlx::types::chrono;
 pub use sqlx::PgPool;
-use std::env;
 use url::Url;
 use uuid::Uuid;
+
+use crate::openai_utils::generate_summary;
 
 use crate::openai_utils::generate_summary;
 

--- a/db/src/urls.rs
+++ b/db/src/urls.rs
@@ -8,9 +8,8 @@ pub use sqlx::PgPool;
 use url::Url;
 use uuid::Uuid;
 
-use crate::openai_utils::generate_summary;
 
-use crate::openai_utils::{generate_summary, generate_categories};
+use crate::openai_utils::{generate_categories, generate_summary};
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct Page {

--- a/db/src/urls.rs
+++ b/db/src/urls.rs
@@ -8,8 +8,7 @@ pub use sqlx::PgPool;
 use url::Url;
 use uuid::Uuid;
 
-
-use crate::openai_utils::{generate_categories, generate_summary};
+use crate::openai_utils::{generate_summary, generate_categories};
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct Page {
@@ -120,7 +119,7 @@ async fn store_markdown(
 ) -> color_eyre::Result<Markdown> {
     let markdown_content = html2md::parse_html(cleaned_html);
     let summary = generate_summary(&markdown_content).await?;
-    println!("Summary: {summary}");
+    // println!("Summary: {summary}");
 
     let markdown_result = sqlx::query_as!(
         Markdown,
@@ -160,13 +159,13 @@ async fn store_raw_html_in_page_snapshot(
     .await?;
 
     let markdown_result = store_markdown(pool, result.page_snapshot_id, &cleaned_html).await?;
-    println!("Markdown result: {markdown_result:?}");
+    // println!("Markdown result: {markdown_result:?}");
 
     Ok(result)
 }
 
 pub async fn process_page_snapshot(pool: &PgPool, page: Page) -> color_eyre::Result<()> {
     let outcome = store_raw_html_in_page_snapshot(pool, page).await?;
-    println!("Outcome: {outcome:?}");
+    // println!("Outcome: {outcome:?}");
     Ok(())
 }

--- a/db/src/urls.rs
+++ b/db/src/urls.rs
@@ -1,3 +1,4 @@
+use openai::chat::{ChatCompletionBuilder, ChatCompletionMessage, ChatCompletionMessageRole};
 use readability;
 use readability::extractor;
 
@@ -5,6 +6,7 @@ use reqwest;
 pub use sqlx;
 use sqlx::types::chrono;
 pub use sqlx::PgPool;
+use std::env;
 use url::Url;
 use uuid::Uuid;
 
@@ -132,6 +134,7 @@ async fn store_raw_html_in_page_snapshot(
     .await?;
 
     let markdown_result = store_markdown(pool, result.page_snapshot_id, &cleaned_html).await?;
+    println!("Markdown result: {markdown_result:?}");
     println!("Markdown result: {markdown_result:?}");
 
     Ok(result)


### PR DESCRIPTION
This PR we created a second prompt for the AI to generate a category for the article that user wanted to summarize.

The AI generated category is later inserted in the DB under `Category Table`.

### **Quick small updates**

- Created a new migration table named `Category`
- As discussed in our quick chat earlier today, in our `Category` table we decided to create a `Foreign Key reference` to the `markdown_id` in the `Markdown` table.
- <img width="743" alt="Screenshot 2024-06-13 at 5 00 21 PM" src="https://github.com/coreyja/knowledge/assets/55955558/876deddf-bb52-4c7f-bc2f-0227022856b8">


- we made the decision to change in our `clean_raw_html` function to return a `article.content` instead of `article.text`
- <img width="862" alt="Screenshot 2024-06-13 at 5 02 15 PM" src="https://github.com/coreyja/knowledge/assets/55955558/89ca51fd-7971-4674-bb41-2da808e4be36">

