### PR TITLE
Ticket 287 make embedding category table

### DIFF
--- a/.sqlx/query-51e5fc5173f678853a572b61493095e15acb365cd3a522d0c254a6ef2e5e10d5.json
+++ b/.sqlx/query-51e5fc5173f678853a572b61493095e15acb365cd3a522d0c254a6ef2e5e10d5.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO Category (markdown_id, category) VALUES ($1, $2) RETURNING *",
+  "query": "INSERT INTO Category (markdown_id, category, embedding) VALUES ($1, $2, $3) RETURNING *",
   "describe": {
     "columns": [
       {
@@ -12,18 +12,25 @@
         "ordinal": 1,
         "name": "category",
         "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "embedding",
+        "type_info": "Float8Array"
       }
     ],
     "parameters": {
       "Left": [
         "Uuid",
-        "Text"
+        "Text",
+        "Float8Array"
       ]
     },
     "nullable": [
       false,
+      true,
       true
     ]
   },
-  "hash": "e00f7541d12980aeb81b1262ae1ac99387aa58722994825122a2f85145c5972d"
+  "hash": "51e5fc5173f678853a572b61493095e15acb365cd3a522d0c254a6ef2e5e10d5"
 }

--- a/db/migrations/20240613150913_category.up.sql
+++ b/db/migrations/20240613150913_category.up.sql
@@ -1,5 +1,6 @@
 -- Add migration script here
 CREATE TABLE IF NOT EXISTS Category (
     markdown_id UUID PRIMARY KEY REFERENCES Markdown(markdown_id),
-    category TEXT
+    category TEXT,
+    embedding DOUBLE PRECISION[]
 );

--- a/db/migrations/20240613150913_category.up.sql
+++ b/db/migrations/20240613150913_category.up.sql
@@ -1,6 +1,5 @@
 -- Add migration script here
 CREATE TABLE IF NOT EXISTS Category (
     markdown_id UUID PRIMARY KEY REFERENCES Markdown(markdown_id),
-    category TEXT,
-    embedding DOUBLE PRECISION[]
+    category TEXT
 );

--- a/db/migrations/20240619182654_AddEmbeddingToCategory.down.sql
+++ b/db/migrations/20240619182654_AddEmbeddingToCategory.down.sql
@@ -1,0 +1,3 @@
+-- Add migration script here
+ALTER TABLE Category
+DROP COLUMN embedding;

--- a/db/migrations/20240619182654_AddEmbeddingToCategory.up.sql
+++ b/db/migrations/20240619182654_AddEmbeddingToCategory.up.sql
@@ -1,0 +1,2 @@
+-- Add migration script here
+ALTER TABLE Category ADD COLUMN embedding DOUBLE PRECISION[]

--- a/db/src/openai_utils.rs
+++ b/db/src/openai_utils.rs
@@ -1,5 +1,6 @@
 use color_eyre::Result;
 use openai::chat::{ChatCompletionBuilder, ChatCompletionMessage, ChatCompletionMessageRole};
+use openai::embeddings::Embeddings;
 use std::env;
 
 async fn generate_openai_response(prompt: &str, max_tokens: u64) -> Result<String> {
@@ -44,4 +45,9 @@ pub async fn generate_categories(content: &str) -> Result<String> {
         .trim()
         .to_string();
     Ok(category)
+}
+
+pub async fn generate_embedding(text: &str) -> color_eyre::Result<Vec<f64>> {
+    let embedding = Embeddings::create("text-embedding-ada-002", vec![text], "user-id").await?;
+    Ok(embedding.data[0].vec.clone())
 }


### PR DESCRIPTION
In this PR we use `openai::embeddings` rust crate to generate text embeddings for each category and insert the text embeddings in the `embeddings` column in the `Category` Table

Example Usage:
<img width="773" alt="Screenshot 2024-06-17 at 1 23 25 PM" src="https://github.com/coreyja/knowledge/assets/55955558/191bebd7-2ec7-448a-a1bf-391457e52425">
