### PR TITLE
Add Test Error Routes under an Admin Namespace

### DIFF
--- a/web/src/admin.rs
+++ b/web/src/admin.rs
@@ -8,7 +8,7 @@ use cja::app_state::AppState as _;
 use color_eyre::eyre::Context;
 use db::users::User;
 
-use crate::{err, users::ExtractUserError, AppState, WebResult};
+use crate::{err, templates::Template, users::ExtractUserError, AppState, WebResult};
 
 async fn simple_error(_: AdminUser) -> WebResult<()> {
     Err(color_eyre::eyre::eyre!("This is a test error"))?
@@ -73,8 +73,19 @@ fn is_admin(user: &User) -> bool {
     admin_usernames.contains(&user.user_name.as_str())
 }
 
+async fn hello(t: Template, admin: AdminUser) -> WebResult<impl IntoResponse> {
+    Ok(t.render(maud::html! {
+      h1 { "Hello Admin "  (admin.0.user_name) }
+
+      a href="/_/test_errors/simple" { "Test Simple Error" }
+      br;
+      a href="/_/test_errors/sql" { "Test SQL Error" }
+    }))
+}
+
 pub fn routes() -> axum::Router<AppState> {
     axum::Router::new()
+        .route("/", get(hello))
         .route("/test_errors/simple", get(simple_error))
         .route("/test_errors/sql", get(sql_error))
 }

--- a/web/src/admin.rs
+++ b/web/src/admin.rs
@@ -1,0 +1,23 @@
+use axum::{extract::State, routing::get};
+use cja::app_state::AppState as _;
+use color_eyre::eyre::Context;
+
+use crate::{AppState, WebResult};
+
+async fn simple_error() -> WebResult<()> {
+    Err(color_eyre::eyre::eyre!("This is a test error"))?
+}
+
+async fn sql_error(State(app_state): State<AppState>) -> WebResult<()> {
+    let _ = sqlx::query("This is not valid sql")
+        .fetch_one(app_state.db())
+        .await
+        .wrap_err("We meant for this to fail but lets see the error chain")?;
+    Ok(())
+}
+
+pub fn routes() -> axum::Router<AppState> {
+    axum::Router::new()
+        .route("/test_errors/simple", get(simple_error))
+        .route("/test_errors/sql", get(sql_error))
+}

--- a/web/src/err.rs
+++ b/web/src/err.rs
@@ -27,7 +27,7 @@ where
 
 impl IntoResponse for Error {
     fn into_response(self) -> axum::http::Response<axum::body::Body> {
-        error!("Error: {:#?}", self);
+        error!("Web Error: {:#}", self.report);
 
         axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
     }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -1,3 +1,4 @@
+mod admin;
 mod cron;
 mod err;
 mod jobs;

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -2,6 +2,7 @@ use axum::routing::get;
 use axum::routing::post;
 
 use crate::{
+    admin,
     pages::{home, landing, user_dashboard},
     users, AppState,
 };
@@ -9,6 +10,7 @@ use crate::{
 pub fn routes(app_state: AppState) -> axum::Router {
     axum::Router::new()
         .route("/", get(home))
+        .nest("/_", admin::routes())
         .route("/hello", get(landing))
         .route("/dashboard", get(user_dashboard))
         .route("/login", get(users::login::get).post(users::login::post))


### PR DESCRIPTION
I wanted to make sure that the Sentry reporting is working like I wanted for Errors, and the best way to do this was to just create a page that always errored!

So this creates two admin routes that check a list of usernames that will be set as an env var, and if the user is an Admin it fires some test errors
If the user is not an admin we return a 401 UNAUTHORIZED http response