### PR TITLE
ticket-294-Ability-to-see-All-Articles-in-the-Web-UI

### DIFF
--- a/.sqlx/query-251d73a797a0ade9ac5fea51a42b88a3e9190cbafe20927646f3ff5b7c290329.json
+++ b/.sqlx/query-251d73a797a0ade9ac5fea51a42b88a3e9190cbafe20927646f3ff5b7c290329.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM pages WHERE user_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "page_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "url",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "251d73a797a0ade9ac5fea51a42b88a3e9190cbafe20927646f3ff5b7c290329"
+}

--- a/.sqlx/query-6ee8eb40261ebd3c4b571c950017d2d507f4be630eb5aa520591078c52af6c1b.json
+++ b/.sqlx/query-6ee8eb40261ebd3c4b571c950017d2d507f4be630eb5aa520591078c52af6c1b.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM category WHERE markdown_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "markdown_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "category",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "embedding",
+        "type_info": "Float8Array"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "6ee8eb40261ebd3c4b571c950017d2d507f4be630eb5aa520591078c52af6c1b"
+}

--- a/cores/src/urls.rs
+++ b/cores/src/urls.rs
@@ -81,20 +81,3 @@ pub async fn generate_and_store_summary(
 
     Ok(())
 }
-
-// pub async fn persist_article(pool: &PgPool, page: Page) -> color_eyre::Result<PageSnapShot> {
-//     let raw_html = download_raw_html(&page.url).await?;
-//     // let current_time = chrono::Utc::now();
-//     let url = Url::parse(&page.url)?;
-//     let cleaned_html = clean_raw_html(&raw_html, &url)?;
-
-//     let markdown_result = store_in_markdown_table(pool, result.page_snapshot_id, &cleaned_html).await?;
-//     generate_and_store_summary(
-//         pool,
-//         markdown_result.markdown_id,
-//         &markdown_result.content_md,
-//     )
-//     .await?;
-
-//     Ok(result)
-// }

--- a/web/src/jobs/process_article.rs
+++ b/web/src/jobs/process_article.rs
@@ -52,7 +52,7 @@ impl Job<AppState> for ProcessArticle {
             .await
             .unwrap();
 
-        generate_categories(&cleaned_html).await.unwrap();
+        generate_categories(&markdown.summary).await.unwrap();
 
         Ok(())
     }

--- a/web/src/jobs/process_article.rs
+++ b/web/src/jobs/process_article.rs
@@ -1,5 +1,6 @@
 use crate::AppState;
 use cja::{app_state::AppState as _, jobs::Job};
+use cores::openai_utils::generate_categories;
 use miette::IntoDiagnostic;
 
 use url::Url;
@@ -42,7 +43,7 @@ impl Job<AppState> for ProcessArticle {
         )
         .fetch_one(db)
         .await
-        .unwrap(); // Insert a new page snapshot into the database and return the inserted record.
+        .unwrap();
 
         let markdown = store_in_markdown_table(db, page_snapshot).await.unwrap();
         let markdown_id = markdown.markdown_id;
@@ -50,6 +51,8 @@ impl Job<AppState> for ProcessArticle {
         generate_and_store_summary(db, markdown_id, &cleaned_html)
             .await
             .unwrap();
+
+        generate_categories(&cleaned_html).await.unwrap();
 
         Ok(())
     }

--- a/web/src/pages.rs
+++ b/web/src/pages.rs
@@ -2,7 +2,13 @@ use axum::{
     extract::{Path, State},
     response::{IntoResponse, Response},
 };
-use cores::{markdown::Markdown, page_snapshot::PageSnapShot, urls::Page, users::User};
+use cores::{
+    category::Category,
+    markdown::Markdown,
+    page_snapshot::PageSnapShot,
+    urls::Page,
+    users::User,
+};
 
 use crate::{
     templates::{Template, TemplatedPage},
@@ -44,10 +50,8 @@ pub async fn user_dashboard(t: Template, user: User) -> TemplatedPage {
             input type="submit" value="Submit";
         }
 
-        h3 {"My Articles"}
-        p {
-            @let url = format!("/my_articles/{}", user.user_id);
-            a href=(url) { "click" }
+        h3 {
+            a href="/articles" { "My Articles" }
         }
 
 
@@ -75,38 +79,54 @@ pub async fn article_detail(
     .await?;
 
     let markdown = if let Some(page_snapshot) = page_snapshot {
-        sqlx::query_as!(
+        let markdown = sqlx::query_as!(
             Markdown,
             "SELECT * FROM markdown WHERE page_snapshot_id = $1",
             page_snapshot.page_snapshot_id
         )
         .fetch_optional(&state.db)
-        .await?
+        .await?;
+
+        if let Some(markdown) = markdown {
+            let categories = sqlx::query_as!(
+                Category,
+                "SELECT * FROM category WHERE markdown_id = $1",
+                markdown.markdown_id
+            )
+            .fetch_all(&state.db)
+            .await?;
+            Some((markdown, categories))
+        } else {
+            None
+        }
     } else {
         None
     };
-    info!("Fetched Article: {:?}", article);
 
-    info!("Fetched markdown MD: {:?}", markdown);
-
-    Ok(t.render(maud::html! {
-        @if let Some(markdown) = markdown {
-            p { (markdown.summary) }
-        } @else {
+    let rendered_html = if let Some((markdown, categories)) = markdown {
+        maud::html! {
+            ul {
+                @for category in categories {
+                    li { b { "Category: " } (category.category.unwrap_or("No category".to_string())) }
+                }
+            }
+            p { b { "Summary: " }(markdown.summary.as_str()) }
+        }
+    } else {
+        maud::html! {
             p { "Generating snapshot....." }
         }
-    })
-    .into_response())
-}
+    };
 
-#[axum::debug_handler(state = AppState)]
+    Ok(t.render(rendered_html).into_response())
+}
 pub async fn my_articles(
     t: Template,
-    Path(user_id): Path<Uuid>,
     State(state): State<AppState>,
+    user: User,
 ) -> WebResult<Response> {
-    info!("Received request for user_id: {}", user_id);
-    let my_articles = sqlx::query_as!(Page, "SELECT * FROM pages WHERE user_id = $1", user_id)
+    info!("Received request for user_id: {}", user.user_id);
+    let my_articles = sqlx::query_as!(Page, "SELECT * FROM pages WHERE user_id = $1", user.user_id)
         .fetch_all(&state.db)
         .await?;
 
@@ -121,7 +141,9 @@ pub async fn my_articles(
                 @let article_url = format!("/articles/{}", article.page_id);
                 tr {
                     td { (article.url) }
-                    td { a href=(article_url) { "View" } }
+                    td {
+                        a href=(article_url) { "View" }
+                    }
                 }
             }
         }

--- a/web/src/pages.rs
+++ b/web/src/pages.rs
@@ -3,11 +3,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use cores::{
-    category::Category,
-    markdown::Markdown,
-    page_snapshot::PageSnapShot,
-    urls::Page,
-    users::User,
+    category::Category, markdown::Markdown, page_snapshot::PageSnapShot, urls::Page, users::User,
 };
 
 use crate::{

--- a/web/src/pages.rs
+++ b/web/src/pages.rs
@@ -57,12 +57,12 @@ pub async fn user_dashboard(t: Template, user: User) -> TemplatedPage {
 #[axum::debug_handler(state = AppState)]
 pub async fn article_detail(
     t: Template,
-    Path(article_id): Path<Uuid>,
+    Path(page_id): Path<Uuid>,
     State(state): State<AppState>,
 ) -> WebResult<Response> {
-    info!("Fetching article_ID: {}", article_id);
+    info!("Fetching article_ID: {}", page_id);
 
-    let article = sqlx::query_as!(Page, "SELECT * FROM pages WHERE page_id = $1", article_id)
+    let article = sqlx::query_as!(Page, "SELECT * FROM pages WHERE page_id = $1", page_id)
         .fetch_one(&state.db)
         .await?;
 
@@ -118,12 +118,10 @@ pub async fn my_articles(
                 th { "Actions" }
             }
             @for article in my_articles {
-                @let article_url = format!("/articles/{}", article.url);
+                @let article_url = format!("/articles/{}", article.page_id);
                 tr {
                     td { (article.url) }
-                    td {
-                        a href=(article_url) { "View" }
-                    }
+                    td { a href=(article_url) { "View" } }
                 }
             }
         }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -18,8 +18,10 @@ pub fn routes(app_state: AppState) -> axum::Router {
         .route("/login", get(users::login::get).post(users::login::post))
         .route("/signup", get(users::signup::get).post(users::signup::post))
         .route("/logout", get(users::login::logout))
-        .route("/articles", post(users::add_url::insert_article_handler))
+        .route(
+            "/articles",
+            post(users::add_url::insert_article_handler).get(my_articles),
+        )
         .route("/articles/:article_id", get(article_detail))
-        .route("/my_articles/:user_id", get(my_articles))
         .with_state(app_state)
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -2,6 +2,7 @@ use axum::routing::get;
 use axum::routing::post;
 
 use crate::pages::article_detail;
+use crate::pages::my_articles;
 use crate::{
     admin,
     pages::{home, landing, user_dashboard},
@@ -19,5 +20,6 @@ pub fn routes(app_state: AppState) -> axum::Router {
         .route("/logout", get(users::login::logout))
         .route("/articles", post(users::add_url::insert_article_handler))
         .route("/articles/:article_id", get(article_detail))
+        .route("/my_articles/:user_id", get(my_articles))
         .with_state(app_state)
 }

--- a/web/src/users/add_url.rs
+++ b/web/src/users/add_url.rs
@@ -21,7 +21,7 @@ pub async fn insert_article_handler(
     user: User,
     Form(form): Form<ArticleForm>,
 ) -> WebResult<impl IntoResponse> {
-    info!("Received request to insert article: {}", form.url); // Log the received URL
+    info!("Received request to insert article: {}", form.url);
 
     let url = form.url;
     let user_id = user.user_id;


### PR DESCRIPTION
### Summary
In this PR, we added a feature that allows users to view all their listed `urls` in `pages` table. 

Users can click `view` to see the summary and associated categories of each article.


### Key File Changes
`web/src/pages.rs`
- added code to select all `categories` associated with it's `markdown_id`
- Added logic to render article details, including categories and summaries
- Add table structure UI to display articles with a 'view' link, to view articles details.

`web/src/jobs/process_article.rs`
- Generated categories for the `markdown_summary`

`web/src/routes.rs`
- changed the route definition for the path `/articles` to either add a new article via a `POST` request or view a list of articles via a `GET` request.



### Quick Demo
https://github.com/coreyja/knowledge/assets/55955558/56feaec1-4edc-4992-b3ac-32cb02621271

